### PR TITLE
Summary table in Slack alerts more readable

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -245,6 +245,10 @@ class Alerter(object):
                 body += '\n----------------------------------------\n'
         return body
 
+    def get_aggregation_summary_text__maximum_width(self):
+        """Get maximum width allowed for summary text."""
+        return 80
+
     def get_aggregation_summary_text(self, matches):
         text = ''
         if 'aggregation' in self.rule and 'summary_table_fields' in self.rule:
@@ -256,7 +260,7 @@ class Alerter(object):
             text += "Aggregation resulted in the following data for summary_table_fields ==> {0}:\n\n".format(
                 summary_table_fields_with_count
             )
-            text_table = Texttable()
+            text_table = Texttable(width=self.get_aggregation_summary_text__maximum_width())
             text_table.header(summary_table_fields_with_count)
             match_aggregation = {}
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1000,7 +1000,9 @@ class SlackAlerter(Alerter):
         return body
 
     def get_aggregation_summary_text__maximum_width(self):
-        return 75
+        width = super(SlackAlerter, self).get_aggregation_summary_text__maximum_width()
+        # Reduced maximum width for prettier Slack display.
+        return min(width, 75)
 
     def get_aggregation_summary_text(self, matches):
         text = super(SlackAlerter, self).get_aggregation_summary_text(matches)

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -260,7 +260,7 @@ class Alerter(object):
             text += "Aggregation resulted in the following data for summary_table_fields ==> {0}:\n\n".format(
                 summary_table_fields_with_count
             )
-            text_table = Texttable(width=self.get_aggregation_summary_text__maximum_width())
+            text_table = Texttable(max_width=self.get_aggregation_summary_text__maximum_width())
             text_table.header(summary_table_fields_with_count)
             match_aggregation = {}
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -999,6 +999,15 @@ class SlackAlerter(Alerter):
         body = body.replace('>', '&gt;')
         return body
 
+    def get_aggregation_summary_text__maximum_width(self):
+        return 75
+
+    def get_aggregation_summary_text(self, matches):
+        text = super(SlackAlerter, self).get_aggregation_summary_text(matches)
+        if text:
+            text = u'```\n{0}```\n'.format(text)
+        return text
+
     def alert(self, matches):
         body = self.create_alert_body(matches)
 


### PR DESCRIPTION
Following changes to make summary table in Slack alerts more readable:

* Table is in a [code block](https://get.slack.help/hc/en-us/articles/202288908-Format-your-messages)
* Reduce width of table so newlines aren't introduced by Slack

Before:

<img width="689" alt="screen shot 2017-08-15 at 9 20 29 am" src="https://user-images.githubusercontent.com/6165380/29325727-9f8a585c-819d-11e7-8f29-366c7d6c4bcc.png">
<img width="678" alt="screen shot 2017-08-15 at 9 20 38 am" src="https://user-images.githubusercontent.com/6165380/29325728-9f8bc8d6-819d-11e7-8f84-6bd11849896b.png">

After:

<img width="680" alt="screen shot 2017-08-15 at 9 33 07 am" src="https://user-images.githubusercontent.com/6165380/29325740-a47a5948-819d-11e7-909b-deb0388293e3.png">
<img width="667" alt="screen shot 2017-08-15 at 9 33 13 am" src="https://user-images.githubusercontent.com/6165380/29325741-a47b747c-819d-11e7-8db7-14dfad558a80.png">