### PR TITLE
[ENGSUP-1947] Summary table in Slack alerts more readable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## v0.1.18
+
+### Added
+- Added a new alerter "post" based on "simple" which makes POSTS JSON to HTTP endpoints
+- Added an option jira_bump_after_inacitivty to prevent ElastAlert commenting on active JIRA tickets
+
+### Removed
+- Removed "simple" alerter, replaced by "post"
+
 ## v0.1.17
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.1.17
+
+### Added
+- Added a --patience flag to allow Elastalert to wait for Elasticsearch to become available
+- Allow custom PagerDuty alert titles via alert_subject
+
 ## v0.1.16
 
 ### Fixed

--- a/docs/source/elastalert.rst
+++ b/docs/source/elastalert.rst
@@ -179,6 +179,9 @@ The environment variable ``AWS_DEFAULT_PROFILE`` will override this field.
 ``replace_dots_in_field_names``: If ``True``, ElastAlert replaces any dots in field names with an underscore before writing documents to Elasticsearch.
 The default value is ``False``. Elasticsearch 2.0 - 2.3 does not support dots in field names.
 
+``string_multi_field_name``: If set, the suffix to use for the subfield for string multi-fields in Elasticsearch.
+The default value is ``.raw`` for Elasticsearch 2 and ``.keyword`` for Elasticsearch 5.
+
 .. _runningelastalert:
 
 Running ElastAlert

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1625,23 +1625,23 @@ This alert type will send results to a JSON endpoint using HTTP POST. The key na
 
 Required:
 
-``advanced_post_url``: The URL to POST.
-
-``advanced_post_payload``: List of keys:values to use as the content of the POST. Example - ip:clientip will map the value from the clientip index of Elasticsearch to JSON key named ip.
+``http_post_url``: The URL to POST.
 
 Optional:
 
-``advanced_post_static_payload``: Key:value pairs of static parameters to be sent, along with the Elasticsearch results. Put your authentication or other information here.
+``http_post_payload``: List of keys:values to use as the content of the POST. Example - ip:clientip will map the value from the clientip index of Elasticsearch to JSON key named ip. If not defined, all the Elasticsearch keys will be sent.
 
-``advanced_post_proxy``: URL of proxy, if required.
+``http_post_static_payload``: Key:value pairs of static parameters to be sent, along with the Elasticsearch results. Put your authentication or other information here.
+
+``http_post_proxy``: URL of proxy, if required.
 
 Example usage::
 
-    alert: advanced
-    advanced_post_url: "http://example.com/api"
-    advanced_post_payload:
+    alert: post
+    http_post_url: "http://example.com/api"
+    http_post_payload:
       ip: clientip
-    advanced_post_static_payload:
+    http_post_static_payload:
       apikey: abc123
 
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1081,7 +1081,7 @@ or
     - email
     - jira
 
-E-mail subject or JIRA issue summary can also be customized by adding an ``alert_subject`` that contains a custom summary.
+E-mail subjects, JIRA issue summaries, and PagerDuty alerts can also be customized by adding an ``alert_subject`` that contains a custom summary.
 It can be further formatted using standard Python formatting syntax::
 
     alert_subject: "Issue {0} occurred at {1}"
@@ -1480,12 +1480,16 @@ The alerter requires the following option:
 
 Optional:
 
-``pagerduty_incident_key``: If not set pagerduty will trigger a new incident for each alert sent. If set to a unique string per rule pagerduty will identify the incident that this event should be applied.
+``alert_subject``: If set, this will be used as the Incident description within PagerDuty. If not set, ElastAlert will default to using the rule name of the alert for the incident.
+
+``alert_subject_args``: If set, and  ``alert_subject`` is a formattable string, ElastAlert will format the incident key based on the provided array of fields from the rule or match.
+
+``pagerduty_incident_key``: If not set PagerDuty will trigger a new incident for each alert sent. If set to a unique string per rule PagerDuty will identify the incident that this event should be applied.
 If there's no open (i.e. unresolved) incident with this key, a new one will be created. If there's already an open incident with a matching key, this event will be appended to that incident's log.
 
 ``pagerduty_incident_key_args``: If set, and ``pagerduty_incident_key`` is a formattable string, Elastalert will format the incident key based on the provided array of fields from the rule or match.
 
-``pagerduty_proxy``: By default ElastAlert will not use a network proxy to send notifications to Pagerduty. Set this option using ``hostname:port`` if you need to use a proxy.
+``pagerduty_proxy``: By default ElastAlert will not use a network proxy to send notifications to PagerDuty. Set this option using ``hostname:port`` if you need to use a proxy.
 
 Exotel
 ~~~~~~

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -221,7 +221,8 @@ import
 
 ``import``: If specified includes all the settings from this yaml file. This allows common config options to be shared. Note that imported files that aren't
 complete rules should not have a ``.yml`` or ``.yaml`` suffix so that ElastAlert doesn't treat them as rules. Filters in imported files are merged (ANDed)
-with any filters in the rule. (Optional, string, no default)
+with any filters in the rule. You can only have one import per rule, though the imported file can import another file, recursively. The filename 
+can be an absolute path or relative to the rules directory. (Optional, string, no default)
 
 use_ssl
 ^^^^^^^

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1621,7 +1621,7 @@ The stomp_destination field depends on the broker, the /queue/ALERT example is t
 HTTP POST
 ~~~~~~~~~
 
-This alert type will send results to a JSON endpoint using HTTP POST. The key names are configurable so this is compatible with almost any endpoint.
+This alert type will send results to a JSON endpoint using HTTP POST. The key names are configurable so this is compatible with almost any endpoint. By default, the JSON will contain al the items from the match, unless you specify http_post_payload, in which case it will only contain those items.
 
 Required:
 
@@ -1634,6 +1634,8 @@ Optional:
 ``http_post_static_payload``: Key:value pairs of static parameters to be sent, along with the Elasticsearch results. Put your authentication or other information here.
 
 ``http_post_proxy``: URL of proxy, if required.
+
+``http_post_all_values``: Boolean of whether or not to include every key value pair from the match in addition to those in http_post_payload and http_post_static_payload. Defaults to True if http_post_payload is not specified, otherwise False.
 
 Example usage::
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1228,6 +1228,10 @@ STARTTLS.
 ``smtp_auth_file``: The path to a file which contains SMTP authentication credentials. It should be YAML formatted and contain
 two fields, ``user`` and ``password``. If this is not present, no authentication will be attempted.
 
+``smtp_cert_file``: Connect the SMTP host using the given path to a TLS certificate file, default to ``None``.
+
+``smtp_key_file``: Connect the SMTP host using the given path to a TLS key file, default to ``None``.
+
 ``email_reply_to``: This sets the Reply-To header in the email. By default, the from address is ElastAlert@ and the domain will be set
 by the smtp server.
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1618,6 +1618,33 @@ Optional:
 
 The stomp_destination field depends on the broker, the /queue/ALERT example is the nomenclature used by ActiveMQ. Each broker has its own logic.
 
+HTTP POST
+~~~~~~~~~
+
+This alert type will send results to a JSON endpoint using HTTP POST. The key names are configurable so this is compatible with almost any endpoint.
+
+Required:
+
+``advanced_post_url``: The URL to POST.
+
+``advanced_post_payload``: List of keys:values to use as the content of the POST. Example - ip:clientip will map the value from the clientip index of Elasticsearch to JSON key named ip.
+
+Optional:
+
+``advanced_post_static_payload``: Key:value pairs of static parameters to be sent, along with the Elasticsearch results. Put your authentication or other information here.
+
+``advanced_post_proxy``: URL of proxy, if required.
+
+Example usage::
+
+    alert: advanced
+    advanced_post_url: "http://example.com/api"
+    advanced_post_payload:
+      ip: clientip
+    advanced_post_static_payload:
+      apikey: abc123
+
+
 Alerter
 ~~~~~~~
 

--- a/docs/source/ruletypes.rst
+++ b/docs/source/ruletypes.rst
@@ -1315,6 +1315,9 @@ Example usage::
     jira_bump_in_statuses:
       - Open
 
+``jira_bump_after_inactivity``: If this is set, ElastAlert will only comment on tickets that have been inactive for at least this many days.
+It only applies if ``jira_bump_tickets`` is true. Default is 0 days.
+
 Arbitrary Jira fields:
 
 ElastAlert supports setting any arbitrary JIRA field that your jira issue supports. For example, if you had a custom field, called "Affected User", you can set it by providing that field name in ``snake_case`` prefixed with ``jira_``.  These fields can contain primitive strings or arrays of strings. Note that when you create a custom field in your JIRA server, internally, the field is represented as ``customfield_1111``. In elastalert, you may refer to either the public facing name OR the internal representation.

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1333,58 +1333,31 @@ class ServiceNowAlerter(Alerter):
                 'self.servicenow_rest_url': self.servicenow_rest_url}
 
 
-class SimplePostAlerter(Alerter):
-    def __init__(self, rule):
-        super(SimplePostAlerter, self).__init__(rule)
-        simple_webhook_url = self.rule.get('simple_webhook_url')
-        if isinstance(simple_webhook_url, basestring):
-            simple_webhook_url = [simple_webhook_url]
-        self.simple_webhook_url = simple_webhook_url
-        self.simple_proxy = self.rule.get('simple_proxy')
-
-    def alert(self, matches):
-        payload = {
-            'rule': self.rule['name'],
-            'matches': matches
-        }
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json;charset=utf-8"
-        }
-        proxies = {'https': self.simple_proxy} if self.simple_proxy else None
-        for url in self.simple_webhook_url:
-            try:
-                response = requests.post(url, data=json.dumps(payload, cls=DateTimeEncoder), headers=headers, proxies=proxies)
-                response.raise_for_status()
-            except RequestException as e:
-                raise EAException("Error posting simple alert: %s" % e)
-        elastalert_logger.info("Simple alert sent")
-
-    def get_info(self):
-        return {'type': 'simple',
-                'simple_webhook_url': self.simple_webhook_url}
-
-
-class AdvancedPostAlerter(Alerter):
+class HTTPPostAlerter(Alerter):
     """ Requested elasticsearch indices are sent by HTTP POST. Encoded with JSON. """
     def __init__(self, rule):
-        super(AdvancedPostAlerter, self).__init__(rule)
-        post_url = self.rule.get('advanced_post_url')
+        super(HTTPPostAlerter, self).__init__(rule)
+        post_url = self.rule.get('http_post_url')
         if isinstance(post_url, basestring):
             post_url = [post_url]
         self.post_url = post_url
-        self.post_proxy = self.rule.get('advanced_post_proxy')
-        self.post_payload = self.rule.get('advanced_post_payload')
-        self.post_static_payload = self.rule.get('advanced_post_static_payload')
+        self.post_proxy = self.rule.get('http_post_proxy')
+        self.post_payload = self.rule.get('http_post_payload')
+        self.post_static_payload = self.rule.get('http_post_static_payload')
 
     def alert(self, matches):
         """ Each match will trigger a POST to the specified endpoint(s). """
         for match in matches:
             payload = self.post_static_payload if self.post_static_payload else {}
             for es_item in match.items():
-                for post_key, es_key in self.post_payload.items():
-                    if es_key == es_item[0]:
-                        payload[post_key] = es_item[1]
+                if self.post_payload:
+                    for post_key, es_key in self.post_payload.items():
+                        if es_key == es_item[0]:
+                            payload[post_key] = es_item[1]
+                else:
+                    key = es_item[0]
+                    value = es_item[1]
+                    payload[key] = value
 
             headers = {
                 "Content-Type": "application/json",
@@ -1397,9 +1370,9 @@ class AdvancedPostAlerter(Alerter):
                                              headers=headers, proxies=proxies)
                     response.raise_for_status()
                 except RequestException as e:
-                    raise EAException("Error posting advanced alert: %s" % e)
-            elastalert_logger.info("Advanced alert sent.")
+                    raise EAException("Error posting HTTP Post alert: %s" % e)
+            elastalert_logger.info("HTTP Post alert sent.")
 
     def get_info(self):
-        return {'type': 'advanced_post',
-                'advanced_webhook_url': self.advanced_webhook_url}
+        return {'type': 'http_post',
+                'http_post_webhook_url': self.post_url}

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -367,6 +367,8 @@ class EmailAlerter(Alerter):
         self.smtp_port = self.rule.get('smtp_port')
         if self.rule.get('smtp_auth_file'):
             self.get_account(self.rule['smtp_auth_file'])
+        self.smtp_key_file = self.rule.get('smtp_key_file')
+        self.smtp_cert_file = self.rule.get('smtp_cert_file')
         # Convert email to a list if it isn't already
         if isinstance(self.rule['email'], basestring):
             self.rule['email'] = [self.rule['email']]
@@ -417,9 +419,9 @@ class EmailAlerter(Alerter):
         try:
             if self.smtp_ssl:
                 if self.smtp_port:
-                    self.smtp = SMTP_SSL(self.smtp_host, self.smtp_port)
+                    self.smtp = SMTP_SSL(self.smtp_host, self.smtp_port, keyfile=self.smtp_key_file, certfile=self.smtp_cert_file)
                 else:
-                    self.smtp = SMTP_SSL(self.smtp_host)
+                    self.smtp = SMTP_SSL(self.smtp_host, keyfile=self.smtp_key_file, certfile=self.smtp_cert_file)
             else:
                 if self.smtp_port:
                     self.smtp = SMTP(self.smtp_host, self.smtp_port)
@@ -427,7 +429,7 @@ class EmailAlerter(Alerter):
                     self.smtp = SMTP(self.smtp_host)
                 self.smtp.ehlo()
                 if self.smtp.has_extn('STARTTLS'):
-                    self.smtp.starttls()
+                    self.smtp.starttls(keyfile=self.smtp_key_file, certfile=self.smtp_cert_file)
             if 'smtp_auth_file' in self.rule:
                 self.smtp.login(self.user, self.password)
         except (SMTPException, error) as e:

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -518,7 +518,7 @@ class JiraAlerter(Alerter):
         self.bump_tickets = self.rule.get('jira_bump_tickets', False)
         self.bump_not_in_statuses = self.rule.get('jira_bump_not_in_statuses')
         self.bump_in_statuses = self.rule.get('jira_bump_in_statuses')
-        self.bump_after_inactivity = self.rule.get('jira_bump_after_inactivity', self.max_age)
+        self.bump_after_inactivity = self.rule.get('jira_bump_after_inactivity', 0)
         self.watchers = self.rule.get('jira_watchers')
 
         if self.bump_in_statuses and self.bump_not_in_statuses:

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -14,7 +14,6 @@ from smtplib import SMTPAuthenticationError
 from smtplib import SMTPException
 from socket import error
 
-import arrow
 import boto3
 import requests
 import stomp
@@ -30,6 +29,8 @@ from util import EAException
 from util import elastalert_logger
 from util import lookup_es_key
 from util import pretty_ts
+from util import ts_now
+from util import ts_to_dt
 
 
 class DateTimeEncoder(json.JSONEncoder):
@@ -690,8 +691,8 @@ class JiraAlerter(Alerter):
         if self.bump_tickets:
             ticket = self.find_existing_ticket(matches)
             if ticket:
-                inactivity_datetime = arrow.now().replace(days=-self.bump_after_inactivity)
-                if arrow.get(ticket.fields.updated) >= inactivity_datetime:
+                inactivity_datetime = ts_now() - datetime.timedelta(days=self.bump_after_inactivity)
+                if ts_to_dt(ticket.fields.updated) >= inactivity_datetime:
                     if self.pipeline is not None:
                         self.pipeline['jira_ticket'] = None
                         self.pipeline['jira_server'] = self.server

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1045,7 +1045,7 @@ class PagerDutyAlerter(Alerter):
         headers = {'content-type': 'application/json'}
         payload = {
             'service_key': self.pagerduty_service_key,
-            'description': self.rule['name'],
+            'description': self.create_title(matches),
             'event_type': 'trigger',
             'incident_key': self.get_incident_key(matches),
             'client': self.pagerduty_client_name,

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1353,3 +1353,42 @@ class SimplePostAlerter(Alerter):
     def get_info(self):
         return {'type': 'simple',
                 'simple_webhook_url': self.simple_webhook_url}
+
+
+class AdvancedPostAlerter(Alerter):
+    """ Requested elasticsearch indices are sent by HTTP POST. Encoded with JSON. """
+    def __init__(self, rule):
+        super(AdvancedPostAlerter, self).__init__(rule)
+        post_url = self.rule.get('advanced_post_url')
+        if isinstance(post_url, basestring):
+            post_url = [post_url]
+        self.post_url = post_url
+        self.post_proxy = self.rule.get('advanced_post_proxy')
+        self.post_payload = self.rule.get('advanced_post_payload')
+
+    def alert(self, matches):
+        """ Each match will trigger a POST to the specified endpoint(s). """
+        for match in matches:
+            payload = {}
+            for es_item in match.items():
+                for post_key, es_key in self.post_payload.items():
+                    if es_key == es_item[0]:
+                        payload[post_key] = es_item[1]
+
+            headers = {
+                "Content-Type": "application/json",
+                "Accept": "application/json;charset=utf-8"
+            }
+            proxies = {'https': self.post_proxy} if self.post_proxy else None
+            for url in self.post_url:
+                try:
+                    response = requests.post(url, data=json.dumps(payload, cls=DateTimeEncoder),
+                                             headers=headers, proxies=proxies)
+                    response.raise_for_status()
+                except RequestException as e:
+                    raise EAException("Error posting advanced alert: %s" % e)
+            elastalert_logger.info("Advanced alert sent.")
+
+    def get_info(self):
+        return {'type': 'advanced_post',
+                'advanced_webhook_url': self.advanced_webhook_url}

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -245,6 +245,10 @@ class Alerter(object):
                 body += '\n----------------------------------------\n'
         return body
 
+    def get_aggregation_summary_text__maximum_width(self):
+        """Get maximum width allowed for summary text."""
+        return 80
+
     def get_aggregation_summary_text(self, matches):
         text = ''
         if 'aggregation' in self.rule and 'summary_table_fields' in self.rule:
@@ -256,7 +260,7 @@ class Alerter(object):
             text += "Aggregation resulted in the following data for summary_table_fields ==> {0}:\n\n".format(
                 summary_table_fields_with_count
             )
-            text_table = Texttable()
+            text_table = Texttable(width=self.get_aggregation_summary_text__maximum_width())
             text_table.header(summary_table_fields_with_count)
             match_aggregation = {}
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1374,11 +1374,12 @@ class AdvancedPostAlerter(Alerter):
         self.post_url = post_url
         self.post_proxy = self.rule.get('advanced_post_proxy')
         self.post_payload = self.rule.get('advanced_post_payload')
+        self.post_static_payload = self.rule.get('advanced_post_static_payload')
 
     def alert(self, matches):
         """ Each match will trigger a POST to the specified endpoint(s). """
         for match in matches:
-            payload = {}
+            payload = self.post_static_payload if self.post_static_payload else {}
             for es_item in match.items():
                 for post_key, es_key in self.post_payload.items():
                     if es_key == es_item[0]:

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -1000,7 +1000,9 @@ class SlackAlerter(Alerter):
         return body
 
     def get_aggregation_summary_text__maximum_width(self):
-        return 75
+        width = super(SlackAlerter, self).get_aggregation_summary_text__maximum_width()
+        # Reduced maximum width for prettier Slack display.
+        return min(width, 75)
 
     def get_aggregation_summary_text(self, matches):
         text = super(SlackAlerter, self).get_aggregation_summary_text(matches)

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -260,7 +260,7 @@ class Alerter(object):
             text += "Aggregation resulted in the following data for summary_table_fields ==> {0}:\n\n".format(
                 summary_table_fields_with_count
             )
-            text_table = Texttable(width=self.get_aggregation_summary_text__maximum_width())
+            text_table = Texttable(max_width=self.get_aggregation_summary_text__maximum_width())
             text_table.header(summary_table_fields_with_count)
             match_aggregation = {}
 

--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -999,6 +999,15 @@ class SlackAlerter(Alerter):
         body = body.replace('>', '&gt;')
         return body
 
+    def get_aggregation_summary_text__maximum_width(self):
+        return 75
+
+    def get_aggregation_summary_text(self, matches):
+        text = super(SlackAlerter, self).get_aggregation_summary_text(matches)
+        if text:
+            text = u'```\n{0}```\n'.format(text)
+        return text
+
     def alert(self, matches):
         body = self.create_alert_body(matches)
 

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -146,6 +146,7 @@ def load_options(rule, conf, filename, args=None):
     :param rule: A dictionary of parsed YAML from a rule config file.
     :param conf: The global configuration dictionary, used for populating defaults.
     """
+    adjust_deprecated_values(rule)
 
     try:
         rule_schema.validate(rule)
@@ -466,3 +467,14 @@ def get_rule_hashes(conf, use_rule=None):
         with open(rule_file) as fh:
             rule_mod_times[rule_file] = hashlib.sha1(fh.read()).digest()
     return rule_mod_times
+
+
+def adjust_deprecated_values(rule):
+    # From rename of simple HTTP alerter
+    if rule.get('type') == 'simple':
+        rule['type'] = 'http'
+        if 'simple_proxy' in rule:
+            rule['http_post_proxy'] = rule['simple_proxy']
+        if 'simple_webhook_url' in rule:
+            rule['http_post_url'] = rule['simple_webhook_url']
+        logging.warning('"simple" alerter has been renamed "post" and comptability may be removed in a future release.')

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -472,7 +472,7 @@ def get_rule_hashes(conf, use_rule=None):
 def adjust_deprecated_values(rule):
     # From rename of simple HTTP alerter
     if rule.get('type') == 'simple':
-        rule['type'] = 'http'
+        rule['type'] = 'post'
         if 'simple_proxy' in rule:
             rule['http_post_proxy'] = rule['simple_proxy']
         if 'simple_webhook_url' in rule:

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -72,7 +72,8 @@ alerts_mapping = {
     'telegram': alerts.TelegramAlerter,
     'gitter': alerts.GitterAlerter,
     'servicenow': alerts.ServiceNowAlerter,
-    'simple': alerts.SimplePostAlerter
+    'simple': alerts.SimplePostAlerter,
+    'advanced': alerts.AdvancedPostAlerter
 }
 # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list
 # For example, jira goes before email so the ticket # will be added to the resulting email.

--- a/elastalert/config.py
+++ b/elastalert/config.py
@@ -72,8 +72,7 @@ alerts_mapping = {
     'telegram': alerts.TelegramAlerter,
     'gitter': alerts.GitterAlerter,
     'servicenow': alerts.ServiceNowAlerter,
-    'simple': alerts.SimplePostAlerter,
-    'advanced': alerts.AdvancedPostAlerter
+    'post': alerts.HTTPPostAlerter
 }
 # A partial ordering of alert types. Relative order will be preserved in the resulting alerts list
 # For example, jira goes before email so the ticket # will be added to the resulting email.

--- a/elastalert/create_index.py
+++ b/elastalert/create_index.py
@@ -111,6 +111,7 @@ def main():
     es_mapping = {'elastalert': {'properties': {'rule_name': {'index': 'not_analyzed', 'type': 'string'},
                                                 '@timestamp': {'format': 'dateOptionalTime', 'type': 'date'},
                                                 'alert_time': {'format': 'dateOptionalTime', 'type': 'date'},
+                                                'match_time': {'format': 'dateOptionalTime', 'type': 'date'},
                                                 'match_body': {'enabled': False, 'type': 'object'},
                                                 'aggregate_id': {'index': 'not_analyzed', 'type': 'string'}}}}
     past_mapping = {'past_elastalert': {'properties': {'rule_name': {'index': 'not_analyzed', 'type': 'string'},

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -142,6 +142,7 @@ class ElastAlerter():
         self.starttime = self.args.start
         self.disabled_rules = []
         self.replace_dots_in_field_names = self.conf.get('replace_dots_in_field_names', False)
+        self.string_multi_field_name = self.conf.get('string_multi_field_name', False)
 
         self.writeback_es = elasticsearch_client(self.conf)
         self._es_version = None
@@ -857,10 +858,13 @@ class ElastAlerter():
         # Change top_count_keys to .raw
         if 'top_count_keys' in new_rule and new_rule.get('raw_count_keys', True):
             keys = new_rule.get('top_count_keys')
-            if self.is_five():
-                new_rule['top_count_keys'] = [key + '.keyword' if not key.endswith('.keyword') else key for key in keys]
+            if self.string_multi_field_name:
+                string_multi_field_name = self.string_multi_field_name
+            elif self.is_five():
+                string_multi_field_name = '.keyword'
             else:
-                new_rule['top_count_keys'] = [key + '.raw' if not key.endswith('.raw') else key for key in keys]
+                string_multi_field_name = '.raw'
+            new_rule['top_count_keys'] = [key + string_multi_field_name if not key.endswith(string_multi_field_name) else key for key in keys]
 
         if 'download_dashboard' in new_rule['filter']:
             # Download filters from Kibana and set the rules filters to them

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -857,7 +857,6 @@ class ElastAlerter():
 
         # Change top_count_keys to .raw
         if 'top_count_keys' in new_rule and new_rule.get('raw_count_keys', True):
-            keys = new_rule.get('top_count_keys')
             if self.string_multi_field_name:
                 string_multi_field_name = self.string_multi_field_name
             elif self.is_five():
@@ -865,12 +864,9 @@ class ElastAlerter():
             else:
                 string_multi_field_name = '.raw'
 
-            top_count_keys = []
-            for key in keys:
+            for i, key in enumerate(new_rule['top_count_keys']):
                 if not key.endswith(string_multi_field_name):
-                    key += string_multi_field_name
-                top_count_keys.append(key)
-            new_rule['top_count_keys'] = top_count_keys
+                    new_rule['top_count_keys'][i] += string_multi_field_name
 
         if 'download_dashboard' in new_rule['filter']:
             # Download filters from Kibana and set the rules filters to them

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -35,6 +35,7 @@ from util import elastalert_logger
 from util import elasticsearch_client
 from util import format_index
 from util import lookup_es_key
+from util import parse_deadline
 from util import pretty_ts
 from util import replace_dots_in_field_names
 from util import seconds
@@ -1543,10 +1544,7 @@ class ElastAlerter():
             silence_cache_key = self.rules[0]['name'] + "._silence"
 
         try:
-            unit, num = self.args.silence.split('=')
-            silence_time = datetime.timedelta(**{unit: int(num)})
-            # Double conversion to add tzinfo
-            silence_ts = ts_to_dt(dt_to_ts(silence_time + datetime.datetime.utcnow()))
+            silence_ts = parse_deadline(self.args.silence)
         except (ValueError, TypeError):
             logging.error('%s is not a valid time period' % (self.args.silence))
             exit(1)

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -864,7 +864,13 @@ class ElastAlerter():
                 string_multi_field_name = '.keyword'
             else:
                 string_multi_field_name = '.raw'
-            new_rule['top_count_keys'] = [key + string_multi_field_name if not key.endswith(string_multi_field_name) else key for key in keys]
+
+            top_count_keys = []
+            for key in keys:
+                if not key.endswith(string_multi_field_name):
+                    key += string_multi_field_name
+                top_count_keys.append(key)
+            new_rule['top_count_keys'] = top_count_keys
 
         if 'download_dashboard' in new_rule['filter']:
             # Download filters from Kibana and set the rules filters to them

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -81,7 +81,7 @@ class ElastAlerter():
         parser.add_argument('--verbose', action='store_true', dest='verbose', help='Increase verbosity without suppressing alerts')
         parser.add_argument('--patience', action='store', dest='timeout',
                             type=parse_duration,
-                            default=datetime.timedelta(seconds=30),
+                            default=datetime.timedelta(),
                             help='Maximum time to wait for ElasticSearch to become responsive.  Usage: '
                             '--patience <units>=<number>. e.g. --patience minutes=5')
         parser.add_argument(
@@ -1015,6 +1015,10 @@ class ElastAlerter():
 
         # Elapsed time is a floating point number of seconds.
         timeout = timeout.total_seconds()
+
+        # Don't poll unless we're asked to.
+        if timeout <= 0.0:
+            return
 
         # Periodically poll ElasticSearch.  Keep going until ElasticSearch is
         # responsive *and* the writeback index exists.

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -136,7 +136,7 @@ class ElastAlerter():
         self.replace_dots_in_field_names = self.conf.get('replace_dots_in_field_names', False)
 
         self.writeback_es = elasticsearch_client(self.conf)
-        self.es_version = self.get_version()
+        self._es_version = None
 
         remove = []
         for rule in self.rules:
@@ -150,6 +150,12 @@ class ElastAlerter():
     def get_version(self):
         info = self.writeback_es.info()
         return info['version']['number']
+
+    @property
+    def es_version(self):
+        if self._es_version is None:
+            self._es_version = self.get_version()
+        return self._es_version
 
     def is_five(self):
         return self.es_version.startswith('5')

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -1334,12 +1334,19 @@ class ElastAlerter():
                 agg_id = res['_id']
 
     def get_alert_body(self, match, rule, alert_sent, alert_time, alert_exception=None):
-        body = {'match_body': match}
-        body['rule_name'] = rule['name']
+        body = {
+            'match_body': match,
+            'rule_name': rule['name'],
+            'alert_info': rule['alert'][0].get_info(),
+            'alert_sent': alert_sent,
+            'alert_time': alert_time
+        }
+
+        match_time = lookup_es_key(match, rule['timestamp_field'])
+        if match_time is not None:
+            body['match_time'] = match_time
+
         # TODO record info about multiple alerts
-        body['alert_info'] = rule['alert'][0].get_info()
-        body['alert_sent'] = alert_sent
-        body['alert_time'] = alert_time
 
         # If the alert failed to send, record the exception
         if not alert_sent:

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -604,7 +604,7 @@ class NewTermsRule(RuleType):
             tmp_start = start
             tmp_end = min(start + step, end)
 
-            time_filter = {self.rules['timestamp_field']: {'lt': dt_to_ts(tmp_end), 'gte': dt_to_ts(tmp_start)}}
+            time_filter = {self.rules['timestamp_field']: {'lt': self.rules['dt_to_ts'](tmp_end), 'gte': self.rules['dt_to_ts'](tmp_start)}}
             query_template['filter'] = {'bool': {'must': [{'range': time_filter}]}}
             query = {'aggs': {'filtered': query_template}}
             # For composite keys, we will need to perform sub-aggregations
@@ -650,7 +650,7 @@ class NewTermsRule(RuleType):
                     break
                 tmp_start = tmp_end
                 tmp_end = min(tmp_start + step, end)
-                time_filter[self.rules['timestamp_field']] = {'lt': dt_to_ts(tmp_end), 'gte': dt_to_ts(tmp_start)}
+                time_filter[self.rules['timestamp_field']] = {'lt': self.rules['dt_to_ts'](tmp_end), 'gte': self.rules['dt_to_ts'](tmp_start)}
 
             for key, values in self.seen_values.iteritems():
                 if not values:

--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -650,7 +650,8 @@ class NewTermsRule(RuleType):
                     break
                 tmp_start = tmp_end
                 tmp_end = min(tmp_start + step, end)
-                time_filter[self.rules['timestamp_field']] = {'lt': self.rules['dt_to_ts'](tmp_end), 'gte': self.rules['dt_to_ts'](tmp_start)}
+                time_filter[self.rules['timestamp_field']] = {'lt': self.rules['dt_to_ts'](tmp_end),
+                                                              'gte': self.rules['dt_to_ts'](tmp_start)}
 
             for key, values in self.seen_values.iteritems():
                 if not values:

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -237,7 +237,7 @@ def dt_to_unix(dt):
 
 
 def dt_to_unixms(dt):
-    return dt_to_unix(dt) * 1000
+    return int(dt_to_unix(dt) * 1000)
 
 
 def cronite_datetime_to_timestamp(self, d):

--- a/elastalert/util.py
+++ b/elastalert/util.py
@@ -342,3 +342,15 @@ def build_es_conn_config(conf):
         parsed_conf['es_url_prefix'] = conf['es_url_prefix']
 
     return parsed_conf
+
+
+def parse_duration(value):
+    """Convert ``unit=num`` spec into a ``timedelta`` object."""
+    unit, num = value.split('=')
+    return datetime.timedelta(**{unit: int(num)})
+
+
+def parse_deadline(value):
+    """Convert ``unit=num`` spec into a ``datetime`` object."""
+    duration = parse_duration(value)
+    return ts_now() + duration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-arrow==0.10.0
 aws-requests-auth>=0.3.0
 blist>=1.3.6
 boto3>=1.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+arrow==0.10.0
 aws-requests-auth>=0.3.0
 blist>=1.3.6
 boto3>=1.4.4

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 base_dir = os.path.dirname(__file__)
 setup(
     name='elastalert',
-    version='0.1.16',
+    version='0.1.17',
     description='Runs custom filters on Elasticsearch and alerts on matches',
     author='Quentin Long',
     author_email='qlo@yelp.com',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 base_dir = os.path.dirname(__file__)
 setup(
     name='elastalert',
-    version='0.1.17',
+    version='0.1.18',
     description='Runs custom filters on Elasticsearch and alerts on matches',
     author='Quentin Long',
     author_email='qlo@yelp.com',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     packages=find_packages(),
     package_data={'elastalert': ['schema.yaml']},
     install_requires=[
-        'arrow>=0.10.0',
         'aws-requests-auth>=0.3.0',
         'blist>=1.3.6',
         'boto3>=1.4.4',

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     packages=find_packages(),
     package_data={'elastalert': ['schema.yaml']},
     install_requires=[
+        'arrow>=0.10.0',
         'aws-requests-auth>=0.3.0',
         'blist>=1.3.6',
         'boto3>=1.4.4',

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1026,8 +1026,8 @@ def test_advanced_alerter():
         'name': 'Test Advanced Alerter Rule',
         'type': 'any',
         'advanced_post_url': 'http://test.webhook.url',
-        'alert_subject': 'Test Advanced Alerter',
         'advanced_post_payload': {'posted_name': 'somefield'},
+        'advanced_post_static_payload': {'name': 'AdvancedAlerter'},
         'alert': []
     }
     load_modules(rule)
@@ -1039,7 +1039,8 @@ def test_advanced_alerter():
     with mock.patch('requests.post') as mock_post_request:
         alert.alert([match])
     expected_data = {
-        'posted_name': 'foobarbaz'
+        'posted_name': 'foobarbaz',
+        'name': 'AdvancedAlerter'
     }
     mock_post_request.assert_called_once_with(
         rule['advanced_post_url'],

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -101,7 +101,7 @@ def test_email():
         expected = [mock.call('localhost'),
                     mock.call().ehlo(),
                     mock.call().has_extn('STARTTLS'),
-                    mock.call().starttls(),
+                    mock.call().starttls(certfile=None, keyfile=None),
                     mock.call().sendmail(mock.ANY, ['testing@test.test', 'test@test.test'], mock.ANY),
                     mock.call().close()]
         assert mock_smtp.mock_calls == expected
@@ -166,7 +166,7 @@ def test_email_with_unicode_strings():
         expected = [mock.call('localhost'),
                     mock.call().ehlo(),
                     mock.call().has_extn('STARTTLS'),
-                    mock.call().starttls(),
+                    mock.call().starttls(certfile=None, keyfile=None),
                     mock.call().sendmail(mock.ANY, [u'testing@test.test'], mock.ANY),
                     mock.call().close()]
         assert mock_smtp.mock_calls == expected
@@ -193,7 +193,29 @@ def test_email_with_auth():
         expected = [mock.call('localhost'),
                     mock.call().ehlo(),
                     mock.call().has_extn('STARTTLS'),
-                    mock.call().starttls(),
+                    mock.call().starttls(certfile=None, keyfile=None),
+                    mock.call().login('someone', 'hunter2'),
+                    mock.call().sendmail(mock.ANY, ['testing@test.test', 'test@test.test'], mock.ANY),
+                    mock.call().close()]
+        assert mock_smtp.mock_calls == expected
+
+
+def test_email_with_cert_key():
+    rule = {'name': 'test alert', 'email': ['testing@test.test', 'test@test.test'], 'from_addr': 'testfrom@test.test',
+            'type': mock_rule(), 'timestamp_field': '@timestamp', 'email_reply_to': 'test@example.com',
+            'alert_subject': 'Test alert for {0}', 'alert_subject_args': ['test_term'], 'smtp_auth_file': 'file.txt',
+            'smtp_cert_file': 'dummy/cert.crt', 'smtp_key_file': 'dummy/client.key'}
+    with mock.patch('elastalert.alerts.SMTP') as mock_smtp:
+        with mock.patch('elastalert.alerts.yaml_loader') as mock_open:
+            mock_open.return_value = {'user': 'someone', 'password': 'hunter2'}
+            mock_smtp.return_value = mock.Mock()
+            alert = EmailAlerter(rule)
+
+        alert.alert([{'test_term': 'test_value'}])
+        expected = [mock.call('localhost'),
+                    mock.call().ehlo(),
+                    mock.call().has_extn('STARTTLS'),
+                    mock.call().starttls(certfile='dummy/cert.crt', keyfile='dummy/client.key'),
                     mock.call().login('someone', 'hunter2'),
                     mock.call().sendmail(mock.ANY, ['testing@test.test', 'test@test.test'], mock.ANY),
                     mock.call().close()]
@@ -212,7 +234,7 @@ def test_email_with_cc():
         expected = [mock.call('localhost'),
                     mock.call().ehlo(),
                     mock.call().has_extn('STARTTLS'),
-                    mock.call().starttls(),
+                    mock.call().starttls(certfile=None, keyfile=None),
                     mock.call().sendmail(mock.ANY, ['testing@test.test', 'test@test.test', 'tester@testing.testing'], mock.ANY),
                     mock.call().close()]
         assert mock_smtp.mock_calls == expected
@@ -237,7 +259,7 @@ def test_email_with_bcc():
         expected = [mock.call('localhost'),
                     mock.call().ehlo(),
                     mock.call().has_extn('STARTTLS'),
-                    mock.call().starttls(),
+                    mock.call().starttls(certfile=None, keyfile=None),
                     mock.call().sendmail(mock.ANY, ['testing@test.test', 'test@test.test', 'tester@testing.testing'], mock.ANY),
                     mock.call().close()]
         assert mock_smtp.mock_calls == expected
@@ -262,7 +284,7 @@ def test_email_with_cc_and_bcc():
         expected = [mock.call('localhost'),
                     mock.call().ehlo(),
                     mock.call().has_extn('STARTTLS'),
-                    mock.call().starttls(),
+                    mock.call().starttls(certfile=None, keyfile=None),
                     mock.call().sendmail(
                         mock.ANY,
                         [
@@ -306,7 +328,7 @@ def test_email_with_args():
         expected = [mock.call('localhost'),
                     mock.call().ehlo(),
                     mock.call().has_extn('STARTTLS'),
-                    mock.call().starttls(),
+                    mock.call().starttls(certfile=None, keyfile=None),
                     mock.call().sendmail(mock.ANY, ['testing@test.test', 'test@test.test'], mock.ANY),
                     mock.call().close()]
         assert mock_smtp.mock_calls == expected

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -16,8 +16,7 @@ from elastalert.alerts import JiraAlerter
 from elastalert.alerts import JiraFormattedMatchString
 from elastalert.alerts import MsTeamsAlerter
 from elastalert.alerts import PagerDutyAlerter
-from elastalert.alerts import SimplePostAlerter
-from elastalert.alerts import AdvancedPostAlerter
+from elastalert.alerts import HTTPPostAlerter
 from elastalert.alerts import SlackAlerter
 from elastalert.config import load_modules
 from elastalert.opsgenie import OpsGenieAlerter
@@ -992,46 +991,17 @@ def test_slack_uses_custom_slack_channel():
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
-def test_simple_alerter():
+def test_http_alerter_with_payload():
     rule = {
-        'name': 'Test Simple Rule',
+        'name': 'Test HTTP Post Alerter With Payload',
         'type': 'any',
-        'simple_webhook_url': 'http://test.webhook.url',
-        'alert_subject': 'Cool subject',
+        'http_post_url': 'http://test.webhook.url',
+        'http_post_payload': {'posted_name': 'somefield'},
+        'http_post_static_payload': {'name': 'somestaticname'},
         'alert': []
     }
     load_modules(rule)
-    alert = SimplePostAlerter(rule)
-    match = {
-        '@timestamp': '2017-01-01T00:00:00',
-        'somefield': 'foobarbaz'
-    }
-    with mock.patch('requests.post') as mock_post_request:
-        alert.alert([match])
-    expected_data = {
-        'rule': rule['name'],
-        'matches': [match]
-    }
-    mock_post_request.assert_called_once_with(
-        rule['simple_webhook_url'],
-        data=mock.ANY,
-        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
-        proxies=None
-    )
-    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
-
-
-def test_advanced_alerter():
-    rule = {
-        'name': 'Test Advanced Alerter Rule',
-        'type': 'any',
-        'advanced_post_url': 'http://test.webhook.url',
-        'advanced_post_payload': {'posted_name': 'somefield'},
-        'advanced_post_static_payload': {'name': 'AdvancedAlerter'},
-        'alert': []
-    }
-    load_modules(rule)
-    alert = AdvancedPostAlerter(rule)
+    alert = HTTPPostAlerter(rule)
     match = {
         '@timestamp': '2017-01-01T00:00:00',
         'somefield': 'foobarbaz'
@@ -1040,10 +1010,40 @@ def test_advanced_alerter():
         alert.alert([match])
     expected_data = {
         'posted_name': 'foobarbaz',
-        'name': 'AdvancedAlerter'
+        'name': 'somestaticname'
     }
     mock_post_request.assert_called_once_with(
-        rule['advanced_post_url'],
+        rule['http_post_url'],
+        data=mock.ANY,
+        headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
+        proxies=None
+    )
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+
+
+def test_http_alerter_without_payload():
+    rule = {
+        'name': 'Test HTTP Post Alerter Without Payload',
+        'type': 'any',
+        'http_post_url': 'http://test.webhook.url',
+        'http_post_static_payload': {'name': 'somestaticname'},
+        'alert': []
+    }
+    load_modules(rule)
+    alert = HTTPPostAlerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'somefield': 'foobarbaz',
+        'name': 'somestaticname'
+    }
+    mock_post_request.assert_called_once_with(
+        rule['http_post_url'],
         data=mock.ANY,
         headers={'Content-Type': 'application/json', 'Accept': 'application/json;charset=utf-8'},
         proxies=None

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -4,7 +4,6 @@ import json
 import subprocess
 from contextlib import nested
 
-import arrow
 import mock
 import pytest
 from jira.exceptions import JIRAError
@@ -23,6 +22,7 @@ from elastalert.alerts import SlackAlerter
 from elastalert.config import load_modules
 from elastalert.opsgenie import OpsGenieAlerter
 from elastalert.util import ts_add
+from elastalert.util import ts_now
 
 
 class mock_rule:
@@ -502,7 +502,7 @@ def test_jira():
     mock_issue = mock.Mock()
 
     # Check ticket is bumped if it is updated 4 days ago
-    mock_issue.fields.updated = str(arrow.now().replace(days=-4))
+    mock_issue.fields.updated = str(ts_now() - datetime.timedelta(days=4))
     with nested(
         mock.patch('elastalert.alerts.JIRA'),
         mock.patch('elastalert.alerts.yaml_loader')
@@ -520,7 +520,7 @@ def test_jira():
         assert '().add_comment' == mock_jira.mock_calls[4][0]
 
     # Check ticket is bumped is not bumped if ticket is updated right now
-    mock_issue.fields.updated = str(arrow.now())
+    mock_issue.fields.updated = str(ts_now())
     with nested(
         mock.patch('elastalert.alerts.JIRA'),
         mock.patch('elastalert.alerts.yaml_loader')
@@ -533,7 +533,7 @@ def test_jira():
 
         alert = JiraAlerter(rule)
         alert.alert([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
-        # Check add_comment is called
+        # Only 4 calls for mock_jira since add_comment is not called
         assert len(mock_jira.mock_calls) == 4
 
 

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 from contextlib import nested
 
+import arrow
 import mock
 import pytest
 from jira.exceptions import JIRAError
@@ -495,6 +496,45 @@ def test_jira():
         alert.alert([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
 
     assert mock_jira.mock_calls == expected
+
+    # Only bump after 3d of inactivity
+    rule['jira_bump_after_inactivity'] = 3
+    mock_issue = mock.Mock()
+
+    # Check ticket is bumped if it is updated 4 days ago
+    mock_issue.fields.updated = str(arrow.now().replace(days=-4))
+    with nested(
+        mock.patch('elastalert.alerts.JIRA'),
+        mock.patch('elastalert.alerts.yaml_loader')
+    ) as (mock_jira, mock_open):
+        mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
+        mock_jira.return_value = mock.Mock()
+        mock_jira.return_value.search_issues.return_value = [mock_issue]
+        mock_jira.return_value.priorities.return_value = [mock_priority]
+        mock_jira.return_value.fields.return_value = []
+
+        alert = JiraAlerter(rule)
+        alert.alert([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
+        # Check add_comment is called
+        assert len(mock_jira.mock_calls) == 5
+        assert '().add_comment' == mock_jira.mock_calls[4][0]
+
+    # Check ticket is bumped is not bumped if ticket is updated right now
+    mock_issue.fields.updated = str(arrow.now())
+    with nested(
+        mock.patch('elastalert.alerts.JIRA'),
+        mock.patch('elastalert.alerts.yaml_loader')
+    ) as (mock_jira, mock_open):
+        mock_open.return_value = {'user': 'jirauser', 'password': 'jirapassword'}
+        mock_jira.return_value = mock.Mock()
+        mock_jira.return_value.search_issues.return_value = [mock_issue]
+        mock_jira.return_value.priorities.return_value = [mock_priority]
+        mock_jira.return_value.fields.return_value = []
+
+        alert = JiraAlerter(rule)
+        alert.alert([{'test_term': 'test_value', '@timestamp': '2014-10-31T00:00:00'}])
+        # Check add_comment is called
+        assert len(mock_jira.mock_calls) == 4
 
 
 def test_jira_arbitrary_field_support():

--- a/tests/alerts_test.py
+++ b/tests/alerts_test.py
@@ -1103,6 +1103,74 @@ def test_pagerduty_alerter_custom_incident_key_with_args():
     assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
 
 
+def test_pagerduty_alerter_custom_alert_subject():
+    rule = {
+        'name': 'Test PD Rule',
+        'type': 'any',
+        'alert_subject': 'Hungry kittens',
+        'pagerduty_service_key': 'magicalbadgers',
+        'pagerduty_client_name': 'ponies inc.',
+        'pagerduty_incident_key': 'custom {0}',
+        'pagerduty_incident_key_args': ['somefield'],
+        'alert': []
+    }
+    load_modules(rule)
+    alert = PagerDutyAlerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'somefield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'client': 'ponies inc.',
+        'description': 'Hungry kittens',
+        'details': {
+            'information': 'Test PD Rule\n\n@timestamp: 2017-01-01T00:00:00\nsomefield: foobarbaz\n'
+        },
+        'event_type': 'trigger',
+        'incident_key': 'custom foobarbaz',
+        'service_key': 'magicalbadgers',
+    }
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+
+
+def test_pagerduty_alerter_custom_alert_subject_with_args():
+    rule = {
+        'name': 'Test PD Rule',
+        'type': 'any',
+        'alert_subject': '{0} kittens',
+        'alert_subject_args': ['somefield'],
+        'pagerduty_service_key': 'magicalbadgers',
+        'pagerduty_client_name': 'ponies inc.',
+        'pagerduty_incident_key': 'custom {0}',
+        'pagerduty_incident_key_args': ['someotherfield'],
+        'alert': []
+    }
+    load_modules(rule)
+    alert = PagerDutyAlerter(rule)
+    match = {
+        '@timestamp': '2017-01-01T00:00:00',
+        'somefield': 'Stinky',
+        'someotherfield': 'foobarbaz'
+    }
+    with mock.patch('requests.post') as mock_post_request:
+        alert.alert([match])
+    expected_data = {
+        'client': 'ponies inc.',
+        'description': 'Stinky kittens',
+        'details': {
+            'information': 'Test PD Rule\n\n@timestamp: 2017-01-01T00:00:00\nsomefield: Stinky\nsomeotherfield: foobarbaz\n'
+        },
+        'event_type': 'trigger',
+        'incident_key': 'custom foobarbaz',
+        'service_key': 'magicalbadgers',
+    }
+    mock_post_request.assert_called_once_with(alert.url, data=mock.ANY, headers={'content-type': 'application/json'}, proxies=None)
+    assert expected_data == json.loads(mock_post_request.call_args_list[0][1]['data'])
+
+
 def test_alert_text_kw(ea):
     rule = ea.rules[0].copy()
     rule['alert_text'] = '{field} at {time}'

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -745,6 +745,7 @@ def test_get_starttime(ea):
     endtime = '2015-01-01T00:00:00Z'
     mock_es = mock.Mock()
     mock_es.search.return_value = {'hits': {'hits': [{'_source': {'endtime': endtime}}]}}
+    mock_es.info.return_value = {'version': {'number': '2.0'}}
     ea.writeback_es = mock_es
 
     # 4 days old, will return endtime

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 
+import logging
 import mock
 import os
 import pytest
@@ -12,6 +13,23 @@ from elastalert.util import ts_to_dt
 
 
 mock_info = {'status': 200, 'name': 'foo', 'version': {'number': '2.0'}}
+
+
+@pytest.fixture(scope='function', autouse=True)
+def reset_loggers():
+    """Prevent logging handlers from capturing temporary file handles.
+
+    For example, a test that uses the `capsys` fixture and calls
+    `logging.exception()` will initialize logging with a default handler that
+    captures `sys.stderr`.  When the test ends, the file handles will be closed
+    and `sys.stderr` will be returned to its original handle, but the logging
+    will have a dangling reference to the temporary handle used in the `capsys`
+    fixture.
+
+    """
+    logger = logging.getLogger()
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
 
 
 class mock_es_indices_client(object):
@@ -29,6 +47,7 @@ class mock_es_client(object):
         self.index = mock.Mock()
         self.delete = mock.Mock()
         self.info = mock.Mock(return_value=mock_info)
+        self.ping = mock.Mock(return_value=True)
         self.indices = mock_es_indices_client()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,11 @@ from elastalert.util import ts_to_dt
 mock_info = {'status': 200, 'name': 'foo', 'version': {'number': '2.0'}}
 
 
+class mock_es_indices_client(object):
+    def __init__(self):
+        self.exists = mock.Mock(return_value=True)
+
+
 class mock_es_client(object):
     def __init__(self, host='es', port=14900):
         self.host = host
@@ -24,6 +29,7 @@ class mock_es_client(object):
         self.index = mock.Mock()
         self.delete = mock.Mock()
         self.info = mock.Mock(return_value=mock_info)
+        self.indices = mock_es_indices_client()
 
 
 class mock_ruletype(object):

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -18,6 +18,7 @@ from elastalert.ruletypes import NewTermsRule
 from elastalert.ruletypes import PercentageMatchRule
 from elastalert.ruletypes import SpikeRule
 from elastalert.ruletypes import WhitelistRule
+from elastalert.util import dt_to_ts
 from elastalert.util import EAException
 from elastalert.util import ts_now
 from elastalert.util import ts_to_dt
@@ -497,7 +498,8 @@ def test_change():
 def test_new_term():
     rules = {'fields': ['a', 'b'],
              'timestamp_field': '@timestamp',
-             'es_host': 'example.com', 'es_port': 10, 'index': 'logstash'}
+             'es_host': 'example.com', 'es_port': 10, 'index': 'logstash',
+             'ts_to_dt': ts_to_dt, 'dt_to_ts': dt_to_ts}
     mock_res = {'aggregations': {'filtered': {'values': {'buckets': [{'key': 'key1', 'doc_count': 1},
                                                                      {'key': 'key2', 'doc_count': 5}]}}}}
 
@@ -567,7 +569,8 @@ def test_new_term_nested_field():
 
     rules = {'fields': ['a', 'b.c'],
              'timestamp_field': '@timestamp',
-             'es_host': 'example.com', 'es_port': 10, 'index': 'logstash'}
+             'es_host': 'example.com', 'es_port': 10, 'index': 'logstash',
+             'ts_to_dt': ts_to_dt, 'dt_to_ts': dt_to_ts}
     mock_res = {'aggregations': {'filtered': {'values': {'buckets': [{'key': 'key1', 'doc_count': 1},
                                                                      {'key': 'key2', 'doc_count': 5}]}}}}
     with mock.patch('elastalert.ruletypes.elasticsearch_client') as mock_es:
@@ -590,7 +593,8 @@ def test_new_term_with_terms():
     rules = {'fields': ['a'],
              'timestamp_field': '@timestamp',
              'es_host': 'example.com', 'es_port': 10, 'index': 'logstash', 'query_key': 'a',
-             'window_step_size': {'days': 2}}
+             'window_step_size': {'days': 2},
+             'ts_to_dt': ts_to_dt, 'dt_to_ts': dt_to_ts}
     mock_res = {'aggregations': {'filtered': {'values': {'buckets': [{'key': 'key1', 'doc_count': 1},
                                                                      {'key': 'key2', 'doc_count': 5}]}}}}
 
@@ -626,7 +630,8 @@ def test_new_term_with_terms():
 def test_new_term_with_composite_fields():
     rules = {'fields': [['a', 'b', 'c'], ['d', 'e.f']],
              'timestamp_field': '@timestamp',
-             'es_host': 'example.com', 'es_port': 10, 'index': 'logstash'}
+             'es_host': 'example.com', 'es_port': 10, 'index': 'logstash',
+             'ts_to_dt': ts_to_dt, 'dt_to_ts': dt_to_ts}
 
     mock_res = {
         'aggregations': {

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,5 +1,44 @@
 # -*- coding: utf-8 -*-
 from elastalert.util import lookup_es_key, set_es_key, add_raw_postfix, replace_dots_in_field_names
+from elastalert.util import (
+    parse_deadline,
+    parse_duration,
+)
+import mock
+import pytest
+from datetime import (
+    datetime,
+    timedelta,
+)
+from dateutil.parser import parse as dt
+
+
+@pytest.mark.parametrize('spec, expected_delta', [
+    ('hours=2',    timedelta(hours=2)),
+    ('minutes=30', timedelta(minutes=30)),
+    ('seconds=45', timedelta(seconds=45)),
+])
+def test_parse_duration(spec, expected_delta):
+    """``unit=num`` specs can be translated into ``timedelta`` instances."""
+    assert parse_duration(spec) == expected_delta
+
+
+@pytest.mark.parametrize('spec, expected_deadline', [
+    ('hours=2',    dt('2017-07-07T12:00:00.000Z')),
+    ('minutes=30', dt('2017-07-07T10:30:00.000Z')),
+    ('seconds=45', dt('2017-07-07T10:00:45.000Z')),
+])
+def test_parse_deadline(spec, expected_deadline):
+    """``unit=num`` specs can be translated into ``datetime`` instances."""
+
+    # Note: Can't mock ``utcnow`` directly because ``datetime`` is a built-in.
+    class MockDatetime(datetime):
+        @staticmethod
+        def utcnow():
+            return dt('2017-07-07T10:00:00.000Z')
+
+    with mock.patch('datetime.datetime', MockDatetime):
+        assert parse_deadline(spec) == expected_deadline
 
 
 def test_setting_keys(ea):


### PR DESCRIPTION
Following changes to make summary table in Slack alerts more readable:

* Table is in a [code block](https://get.slack.help/hc/en-us/articles/202288908-Format-your-messages)
* Reduce width of table so newlines aren't introduced by Slack

Before:

<img width="689" alt="screen shot 2017-08-15 at 9 20 29 am" src="https://user-images.githubusercontent.com/6165380/29325727-9f8a585c-819d-11e7-8f29-366c7d6c4bcc.png">
<img width="678" alt="screen shot 2017-08-15 at 9 20 38 am" src="https://user-images.githubusercontent.com/6165380/29325728-9f8bc8d6-819d-11e7-8f84-6bd11849896b.png">

After:

<img width="680" alt="screen shot 2017-08-15 at 9 33 07 am" src="https://user-images.githubusercontent.com/6165380/29325740-a47a5948-819d-11e7-909b-deb0388293e3.png">
<img width="667" alt="screen shot 2017-08-15 at 9 33 13 am" src="https://user-images.githubusercontent.com/6165380/29325741-a47b747c-819d-11e7-8db7-14dfad558a80.png">